### PR TITLE
[지도관리자] 간선 생성 유스케이스 에러 추가

### DIFF
--- a/src/map_admin/application/boundaries.py
+++ b/src/map_admin/application/boundaries.py
@@ -63,3 +63,9 @@ class CreateEdgeInputBoundary(ABC):
 
     class NodeNotFoundError(Exception):
         """노드를 찾지 못할 때 발생하는 에러"""
+
+    class ConnectingSameNodeError(Exception):
+        """같은 노드끼리 간선으로 연결할 때 발생하는 에러"""
+
+    class AlreadyConnectedNodesError(Exception):
+        """이미 연결된 노드끼리 간선으로 연결할 때 발생하는 에러"""

--- a/src/map_admin/application/use_cases.py
+++ b/src/map_admin/application/use_cases.py
@@ -17,6 +17,10 @@ from map_admin.application.dtos import (
 )
 from map_admin.application.repositories import NodeRepository
 from map_admin.domain.entities import Node
+from map_admin.domain.exceptions import (
+    AlreadyConnectedNodesError,
+    ConnectingSameNodeError,
+)
 from map_admin.domain.value_objects import Point, RoadQuality
 
 
@@ -111,12 +115,18 @@ class CreateEdgeUseCase(CreateEdgeInputBoundary):
         except NodeRepository.NodeNotFoundError:
             raise super().NodeNotFoundError
 
-        nodes[0].add_edge(
-            other_node=nodes[1],
-            vertical_distance=input_data.vertical_distance,
-            horizontal_distance=input_data.horizontal_distance,
-            is_stair=input_data.is_stair,
-            is_step=input_data.is_step,
-            quality=RoadQuality(input_data.quality),
-        )
+        try:
+            nodes[0].add_edge(
+                other_node=nodes[1],
+                vertical_distance=input_data.vertical_distance,
+                horizontal_distance=input_data.horizontal_distance,
+                is_stair=input_data.is_stair,
+                is_step=input_data.is_step,
+                quality=RoadQuality(input_data.quality),
+            )
+        except ConnectingSameNodeError:
+            raise super().ConnectingSameNodeError
+        except AlreadyConnectedNodesError:
+            raise super().AlreadyConnectedNodesError
+
         self.node_repo.update_node(node=nodes[0])

--- a/src/map_admin/domain/entities.py
+++ b/src/map_admin/domain/entities.py
@@ -2,6 +2,10 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Self
 
+from map_admin.domain.exceptions import (
+    AlreadyConnectedNodesError,
+    ConnectingSameNodeError,
+)
 from map_admin.domain.value_objects import Point, RoadQuality
 
 
@@ -39,10 +43,10 @@ class Node:
         quality: RoadQuality,
     ) -> None:
         if self == other_node:
-            raise ValueError("Edge cannot connect to itself")
+            raise ConnectingSameNodeError
 
         if any(other_node.id in edge.node_ids for edge in self.edges):
-            raise ValueError("Edge already exists")
+            raise AlreadyConnectedNodesError
 
         edge = Edge(
             node_ids=(self.id, other_node.id),
@@ -67,7 +71,7 @@ class Edge:
 
     def __post_init__(self) -> None:
         if self.node_ids[0] == self.node_ids[1]:
-            raise ValueError("Edge cannot connect to itself")
+            raise ConnectingSameNodeError
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Edge):

--- a/src/map_admin/domain/exceptions.py
+++ b/src/map_admin/domain/exceptions.py
@@ -1,0 +1,6 @@
+class ConnectingSameNodeError(Exception):
+    """같은 노드끼리 간선으로 연결할 때 발생하는 에러"""
+
+
+class AlreadyConnectedNodesError(Exception):
+    """이미 연결된 노드끼리 간선으로 연결할 때 발생하는 에러"""

--- a/tests/map_admin/domain/test_edge.py
+++ b/tests/map_admin/domain/test_edge.py
@@ -3,11 +3,12 @@ from decimal import Decimal
 import pytest
 
 from map_admin.domain.entities import Edge
+from map_admin.domain.exceptions import ConnectingSameNodeError
 from map_admin.domain.value_objects import RoadQuality
 
 
 def test_validate_edge_connecting_different_nodes() -> None:
-    with pytest.raises(ValueError, match="Edge cannot connect to itself"):
+    with pytest.raises(ConnectingSameNodeError):
         Edge(
             node_ids=(1, 1),
             vertical_distance=Decimal("1.0"),

--- a/tests/map_admin/domain/test_node.py
+++ b/tests/map_admin/domain/test_node.py
@@ -3,6 +3,10 @@ from decimal import Decimal
 import pytest
 
 from map_admin.domain.entities import Edge, Node
+from map_admin.domain.exceptions import (
+    AlreadyConnectedNodesError,
+    ConnectingSameNodeError,
+)
 from map_admin.domain.value_objects import Point, RoadQuality
 
 
@@ -130,7 +134,7 @@ def test_add_edge_error_with_same_node() -> None:
         edges=[],
     )
 
-    with pytest.raises(ValueError, match="Edge cannot connect to itself"):
+    with pytest.raises(ConnectingSameNodeError):
         node.add_edge(
             other_node=node,
             vertical_distance=Decimal("1.0"),
@@ -171,7 +175,7 @@ def test_add_edge_error_with_existing_edge() -> None:
         quality=RoadQuality.HIGH,
     )
 
-    with pytest.raises(ValueError, match="Edge already exists"):
+    with pytest.raises(AlreadyConnectedNodesError):
         nodes[1].add_edge(
             other_node=nodes[2],
             vertical_distance=Decimal("1.0"),


### PR DESCRIPTION
## Description
간선 생성 유스케이스에서 엔티티 수준에서의 간선 생성 작업 처리 중 발생한 에러를 처리하여 내보냅니다.
유스케이스에서 에러 원인을 구분하기 위해, 노드 엔티티에서 커스텀 예외를 일으키도록 리팩터링합니다.

## Changes
* domain 수준의 에러를 exceptions.py에 정의합니다.
* Node, Edge 엔티티에서 ValueError 대신 새로 정의한 타입의 에러를 일으킵니다.
* CreateEdgeInputBoundary에 유스케이스 수준의 에러를 정의하고, CreateEdgeUseCase에서 도메인 수준 에러에 대한 처리로 유스케이스 수준의 에러를 발생시킵니다.

## Issues and References
