### PR TITLE
[지도관리자] 간선 목록 조회 API 제작

### DIFF
--- a/src/containers.py
+++ b/src/containers.py
@@ -4,6 +4,7 @@ from map_admin.application.use_cases import (
     CreateEdgeUseCase,
     CreateNodeUseCase,
     DeleteNodeUseCase,
+    ListEdgesUseCase,
     ListNodesUseCase,
     PartialUpdateNodeUseCase,
 )
@@ -34,6 +35,10 @@ class Container(containers.DeclarativeContainer):
     )
     delete_node_use_case = providers.Factory(
         DeleteNodeUseCase,
+        node_repo=node_repository,
+    )
+    list_edges_use_case = providers.Factory(
+        ListEdgesUseCase,
         node_repo=node_repository,
     )
     create_edge_use_case = providers.Factory(

--- a/src/map_admin/presentation/apis.py
+++ b/src/map_admin/presentation/apis.py
@@ -10,6 +10,7 @@ from map_admin.application.boundaries import (
     CreateEdgeInputBoundary,
     CreateNodeInputBoundary,
     DeleteNodeInputBoundary,
+    ListEdgesInputBoundary,
     ListNodesInputBoundary,
     PartialUpdateNodeInputBoundary,
 )
@@ -22,6 +23,8 @@ from map_admin.application.dtos import (
 from map_admin.presentation.presenters import (
     CreateNodePydanticPresenter,
     CreateNodePydanticViewModel,
+    ListEdgesPydanticPresenter,
+    ListEdgesPydanticViewModel,
     ListNodesPydanticPresenter,
     ListNodesPydanticViewModel,
 )
@@ -145,6 +148,16 @@ async def delete_node(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Node not found",
         )
+
+
+@router.get("/edges")
+@inject
+async def list_edges(
+    use_case: ListEdgesInputBoundary = Depends(Provide[Container.list_edges_use_case]),
+) -> ListEdgesPydanticViewModel:
+    presenter = ListEdgesPydanticPresenter()
+    use_case.execute(output_boundary=presenter)
+    return presenter.get_view_model()
 
 
 class CreateEdgeRequest(BaseModel):

--- a/src/map_admin/presentation/presenters.py
+++ b/src/map_admin/presentation/presenters.py
@@ -4,9 +4,14 @@ from pydantic import BaseModel
 
 from map_admin.application.boundaries import (
     CreateNodeOutputBoundary,
+    ListEdgesOutputBoundary,
     ListNodesOutputBoundary,
 )
-from map_admin.application.dtos import CreateNodeOutputData, ListNodesOutputData
+from map_admin.application.dtos import (
+    CreateNodeOutputData,
+    ListEdgesOutputData,
+    ListNodesOutputData,
+)
 
 
 class NodePydanticViewModel(BaseModel):
@@ -46,4 +51,48 @@ class CreateNodePydanticPresenter(CreateNodeOutputBoundary):
         )
 
     def get_view_model(self) -> CreateNodePydanticViewModel:
+        return self._view_model
+
+
+class EdgeNodePydanticViewModel(BaseModel):
+    id: int
+    name: str
+
+
+class EdgePydanticViewModel(BaseModel):
+    nodes: tuple[EdgeNodePydanticViewModel, EdgeNodePydanticViewModel]
+    vertical_distance: float
+    horizontal_distance: float
+    is_stair: bool
+    is_step: bool
+    quality: str
+
+
+ListEdgesPydanticViewModel: TypeAlias = list[EdgePydanticViewModel]
+
+
+class ListEdgesPydanticPresenter(ListEdgesOutputBoundary):
+    def present(self, output_data_list: list[ListEdgesOutputData]) -> None:
+        self._view_model: ListEdgesPydanticViewModel = [
+            EdgePydanticViewModel(
+                nodes=(
+                    EdgeNodePydanticViewModel(
+                        id=output_data.nodes[0].id,
+                        name=output_data.nodes[0].name,
+                    ),
+                    EdgeNodePydanticViewModel(
+                        id=output_data.nodes[1].id,
+                        name=output_data.nodes[1].name,
+                    ),
+                ),
+                vertical_distance=float(output_data.vertical_distance),
+                horizontal_distance=float(output_data.horizontal_distance),
+                is_stair=output_data.is_stair,
+                is_step=output_data.is_step,
+                quality=output_data.quality,
+            )
+            for output_data in output_data_list
+        ]
+
+    def get_view_model(self) -> ListEdgesPydanticViewModel:
         return self._view_model

--- a/tests/map_admin/presentation/test_pydantic_presenters.py
+++ b/tests/map_admin/presentation/test_pydantic_presenters.py
@@ -1,9 +1,16 @@
 from decimal import Decimal
 
-from map_admin.application.dtos import CreateNodeOutputData, ListNodesOutputData
+from map_admin.application.dtos import (
+    CreateNodeOutputData,
+    ListEdgesOutputData,
+    ListNodesOutputData,
+)
 from map_admin.presentation.presenters import (
     CreateNodePydanticPresenter,
     CreateNodePydanticViewModel,
+    EdgeNodePydanticViewModel,
+    EdgePydanticViewModel,
+    ListEdgesPydanticPresenter,
     ListNodesPydanticPresenter,
     NodePydanticViewModel,
 )
@@ -51,3 +58,58 @@ def test_present_create_node() -> None:
     presenter.present(output_data=output_data)
 
     assert presenter.get_view_model() == CreateNodePydanticViewModel(id=1)
+
+
+def test_present_list_edges() -> None:
+    output_data_list: list[ListEdgesOutputData] = [
+        ListEdgesOutputData(
+            nodes=(
+                ListEdgesOutputData.Node(id=1, name="A"),
+                ListEdgesOutputData.Node(id=2, name="B"),
+            ),
+            vertical_distance=Decimal("1.0"),
+            horizontal_distance=Decimal("2.0"),
+            is_stair=False,
+            is_step=False,
+            quality="상",
+        ),
+        ListEdgesOutputData(
+            nodes=(
+                ListEdgesOutputData.Node(id=1, name="A"),
+                ListEdgesOutputData.Node(id=3, name="C"),
+            ),
+            vertical_distance=Decimal("3.0"),
+            horizontal_distance=Decimal("4.0"),
+            is_stair=False,
+            is_step=False,
+            quality="상",
+        ),
+    ]
+
+    presenter = ListEdgesPydanticPresenter()
+    presenter.present(output_data_list=output_data_list)
+
+    assert presenter.get_view_model() == [
+        EdgePydanticViewModel(
+            nodes=(
+                EdgeNodePydanticViewModel(id=1, name="A"),
+                EdgeNodePydanticViewModel(id=2, name="B"),
+            ),
+            vertical_distance=1.0,
+            horizontal_distance=2.0,
+            is_stair=False,
+            is_step=False,
+            quality="상",
+        ),
+        EdgePydanticViewModel(
+            nodes=(
+                EdgeNodePydanticViewModel(id=1, name="A"),
+                EdgeNodePydanticViewModel(id=3, name="C"),
+            ),
+            vertical_distance=3.0,
+            horizontal_distance=4.0,
+            is_stair=False,
+            is_step=False,
+            quality="상",
+        ),
+    ]


### PR DESCRIPTION
## Description
지도관리자 도메인의 간선 목록을 조회하는 API를 제작합니다. #42 에서 제작한 유스케이스를 사용합니다.

## Changes
* ListEdgesPydanticPresenter와 view model 데이터클래스를 pydantic으로 정의 (+ 테스트 작성)
* path operation list_edges() 정의. 함수에 주입할 provider를 명시

## Issues and References
