### PR TITLE
[지도관리자] 간선 삭제 유스케이스, API 제작

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,12 @@
     "python.analysis.typeCheckingMode": "strict",
     "python.testing.pytestArgs": [
         "tests",
-        "-vv"
+        "-vv",
+        "--showlocals",
+        "--tb=auto",
+        "--no-header",
+        // "--no-summary",
+        "--color=yes"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,

--- a/src/containers.py
+++ b/src/containers.py
@@ -3,6 +3,7 @@ from dependency_injector import containers, providers
 from map_admin.application.use_cases import (
     CreateEdgeUseCase,
     CreateNodeUseCase,
+    DeleteEdgeUseCase,
     DeleteNodeUseCase,
     ListEdgesUseCase,
     ListNodesUseCase,
@@ -48,5 +49,9 @@ class Container(containers.DeclarativeContainer):
     )
     partial_update_edge_use_case = providers.Factory(
         PartialUpdateEdgeUseCase,
+        node_repo=node_repository,
+    )
+    delete_edge_use_case = providers.Factory(
+        DeleteEdgeUseCase,
         node_repo=node_repository,
     )

--- a/src/map_admin/application/boundaries.py
+++ b/src/map_admin/application/boundaries.py
@@ -4,6 +4,7 @@ from map_admin.application.dtos import (
     CreateEdgeInputData,
     CreateNodeInputData,
     CreateNodeOutputData,
+    DeleteEdgeInputData,
     DeleteNodeInputData,
     ListEdgesOutputData,
     ListNodesOutputData,
@@ -88,6 +89,21 @@ class CreateEdgeInputBoundary(ABC):
 class PartialUpdateEdgeInputBoundary(ABC):
     @abstractmethod
     def execute(self, input_data: PartialUpdateEdgeInputData) -> None:
+        raise NotImplementedError
+
+    class NodeNotFoundError(Exception):
+        """노드를 찾지 못할 때 발생하는 에러"""
+
+    class ConnectingSameNodeError(Exception):
+        """같은 노드끼리 간선으로 연결할 때 발생하는 에러"""
+
+    class EdgeNotFoundError(Exception):
+        """간선을 찾지 못할 때 발생하는 에러"""
+
+
+class DeleteEdgeInputBoundary(ABC):
+    @abstractmethod
+    def execute(self, input_data: DeleteEdgeInputData) -> None:
         raise NotImplementedError
 
     class NodeNotFoundError(Exception):

--- a/src/map_admin/application/dtos.py
+++ b/src/map_admin/application/dtos.py
@@ -68,3 +68,8 @@ class PartialUpdateEdgeInputData:
     is_stair: bool | None
     is_step: bool | None
     quality: str | None
+
+
+@dataclass(frozen=True, kw_only=True)
+class DeleteEdgeInputData:
+    node_ids: tuple[int, int]

--- a/src/map_admin/application/use_cases.py
+++ b/src/map_admin/application/use_cases.py
@@ -2,6 +2,7 @@ from map_admin.application.boundaries import (
     CreateEdgeInputBoundary,
     CreateNodeInputBoundary,
     CreateNodeOutputBoundary,
+    DeleteEdgeInputBoundary,
     DeleteNodeInputBoundary,
     ListEdgesInputBoundary,
     ListEdgesOutputBoundary,
@@ -14,6 +15,7 @@ from map_admin.application.dtos import (
     CreateEdgeInputData,
     CreateNodeInputData,
     CreateNodeOutputData,
+    DeleteEdgeInputData,
     DeleteNodeInputData,
     ListEdgesOutputData,
     ListNodesOutputData,
@@ -197,6 +199,29 @@ class PartialUpdateEdgeUseCase(PartialUpdateEdgeInputBoundary):
                     else RoadQuality(input_data.quality)
                 ),
             )
+        except ConnectingSameNodeError:
+            raise super().ConnectingSameNodeError
+        except NoEdgeExistsBetweenNodesError:
+            raise super().EdgeNotFoundError
+
+        self.node_repo.update_node(node=nodes[0])
+
+
+class DeleteEdgeUseCase(DeleteEdgeInputBoundary):
+    def __init__(self, node_repo: NodeRepository) -> None:
+        self.node_repo = node_repo
+
+    def execute(self, input_data: DeleteEdgeInputData) -> None:
+        try:
+            nodes: tuple[Node, Node] = (
+                self.node_repo.get_node_by_id(node_id=input_data.node_ids[0]),
+                self.node_repo.get_node_by_id(node_id=input_data.node_ids[1]),
+            )
+        except NodeRepository.NodeNotFoundError:
+            raise super().NodeNotFoundError
+
+        try:
+            nodes[0].delete_edge(other_node=nodes[1])
         except ConnectingSameNodeError:
             raise super().ConnectingSameNodeError
         except NoEdgeExistsBetweenNodesError:

--- a/src/map_admin/domain/entities.py
+++ b/src/map_admin/domain/entities.py
@@ -93,6 +93,22 @@ class Node:
             edge for edge in other_node.edges if self.id not in edge.node_ids
         ] + [edge]
 
+    def delete_edge(
+        self,
+        other_node: Self,
+    ) -> None:
+        if self == other_node:
+            raise ConnectingSameNodeError
+        try:
+            edge: Edge = next(
+                edge for edge in self.edges if other_node.id in edge.node_ids
+            )
+        except StopIteration:
+            raise NoEdgeExistsBetweenNodesError
+
+        self.edges.remove(edge)
+        other_node.edges.remove(edge)
+
 
 @dataclass(kw_only=True)
 class Edge:

--- a/src/map_admin/presentation/apis.py
+++ b/src/map_admin/presentation/apis.py
@@ -222,7 +222,7 @@ class PartialUpdateEdgeRequest(BaseModel):
 @router.patch("/edges")
 @inject
 async def partial_update_edge(
-    edge: PartialUpdateEdgeRequest,
+    edge: PartialUpdateEdgeRequest,  # TODO: Use path parameter
     use_case: PartialUpdateEdgeInputBoundary = Depends(
         Provide[Container.partial_update_edge_use_case]
     ),
@@ -248,17 +248,17 @@ async def partial_update_edge(
         )
     except PartialUpdateEdgeInputBoundary.NodeNotFoundError:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_400_BAD_REQUEST,  # TODO: Use 404
             detail="Invalid Node ID",
         )
     except PartialUpdateEdgeInputBoundary.ConnectingSameNodeError:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_400_BAD_REQUEST,  # TODO: Use 404
             detail="Same node",
         )
     except PartialUpdateEdgeInputBoundary.EdgeNotFoundError:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_400_BAD_REQUEST,  # TODO: Use 404
             detail="Edge not found",
         )
 

--- a/src/map_admin/presentation/apis.py
+++ b/src/map_admin/presentation/apis.py
@@ -9,6 +9,7 @@ from containers import Container
 from map_admin.application.boundaries import (
     CreateEdgeInputBoundary,
     CreateNodeInputBoundary,
+    DeleteEdgeInputBoundary,
     DeleteNodeInputBoundary,
     ListEdgesInputBoundary,
     ListNodesInputBoundary,
@@ -18,6 +19,7 @@ from map_admin.application.boundaries import (
 from map_admin.application.dtos import (
     CreateEdgeInputData,
     CreateNodeInputData,
+    DeleteEdgeInputData,
     DeleteNodeInputData,
     PartialUpdateEdgeInputData,
     PartialUpdateNodeInputData,
@@ -257,5 +259,54 @@ async def partial_update_edge(
     except PartialUpdateEdgeInputBoundary.EdgeNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Edge not found",
+        )
+
+
+@router.delete(
+    "/edge/{node_id_1}/{node_id_2}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        # TODO: Separate by defining as a new variable
+        status.HTTP_404_NOT_FOUND: {
+            "content": {
+                "application/json": {
+                    "examples": {
+                        "Node Not Found": {"detail": "Invalid Node ID"},
+                        "Connecting same node": {"detail": "Same node"},
+                        "Edge not found": {"detail": "Edge not found"},
+                    },
+                },
+            },
+        },
+    },
+)
+@inject
+async def delete_edge(
+    node_id_1: int,
+    node_id_2: int,
+    use_case: DeleteEdgeInputBoundary = Depends(
+        Provide[Container.delete_edge_use_case]
+    ),
+) -> None:
+    try:
+        use_case.execute(
+            input_data=DeleteEdgeInputData(
+                node_ids=(node_id_1, node_id_2),
+            ),
+        )
+    except DeleteEdgeInputBoundary.NodeNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Invalid Node ID",
+        )
+    except DeleteEdgeInputBoundary.ConnectingSameNodeError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Same node",
+        )
+    except DeleteEdgeInputBoundary.EdgeNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
             detail="Edge not found",
         )

--- a/tests/map_admin/application/test_delete_edge.py
+++ b/tests/map_admin/application/test_delete_edge.py
@@ -1,0 +1,150 @@
+from collections.abc import Callable
+from decimal import Decimal
+from unittest import mock
+
+import pytest
+
+from map_admin.application.dtos import DeleteEdgeInputData
+from map_admin.application.repositories import NodeRepository
+from map_admin.application.use_cases import DeleteEdgeUseCase
+from map_admin.domain.entities import Edge, Node
+from map_admin.domain.value_objects import Point, RoadQuality
+
+
+def test_delete_edge() -> None:
+    nodes: dict[int, Node] = {
+        1: Node(
+            id=1,
+            name="A",
+            point=Point(
+                longitude=Decimal("1.0"),
+                latitude=Decimal("2.0"),
+            ),
+            edges=[
+                Edge(
+                    node_ids=(1, 2),
+                    vertical_distance=Decimal("1.0"),
+                    horizontal_distance=Decimal("2.0"),
+                    is_stair=False,
+                    is_step=False,
+                    quality=RoadQuality.HIGH,
+                ),
+            ],
+        ),
+        2: Node(
+            id=2,
+            name="B",
+            point=Point(
+                longitude=Decimal("3.0"),
+                latitude=Decimal("4.0"),
+            ),
+            edges=[
+                Edge(
+                    node_ids=(1, 2),
+                    vertical_distance=Decimal("1.0"),
+                    horizontal_distance=Decimal("2.0"),
+                    is_stair=False,
+                    is_step=False,
+                    quality=RoadQuality.HIGH,
+                ),
+            ],
+        ),
+    }
+    mock_node_repo = mock.Mock(spec_set=NodeRepository)
+    side_effect: Callable[[int], Node] = lambda node_id: nodes[node_id]
+    mock_node_repo.get_node_by_id.side_effect = side_effect
+
+    DeleteEdgeUseCase(
+        node_repo=mock_node_repo,
+    ).execute(
+        input_data=DeleteEdgeInputData(
+            node_ids=(1, 2),
+        ),
+    )
+
+    assert mock_node_repo.update_node.call_args_list == [
+        mock.call(
+            node=Node(
+                id=1,
+                name="A",
+                point=Point(
+                    longitude=Decimal("1.0"),
+                    latitude=Decimal("2.0"),
+                ),
+                edges=[],
+            ),
+        ),
+    ]
+
+
+def test_delete_edge_with_invalid_node_id() -> None:
+    mock_node_repo = mock.Mock(spec_set=NodeRepository)
+    mock_node_repo.get_node_by_id.side_effect = [NodeRepository.NodeNotFoundError]
+
+    with pytest.raises(DeleteEdgeUseCase.NodeNotFoundError):
+        DeleteEdgeUseCase(
+            node_repo=mock_node_repo,
+        ).execute(
+            input_data=DeleteEdgeInputData(
+                node_ids=(1, 2),
+            ),
+        )
+
+
+def test_delete_edge_with_same_node() -> None:
+    node = Node(
+        id=1,
+        name="A",
+        point=Point(
+            longitude=Decimal("1.0"),
+            latitude=Decimal("2.0"),
+        ),
+    )
+    mock_node_repo = mock.Mock(spec_set=NodeRepository)
+    mock_node_repo.get_node_by_id.side_effect = [node, node]
+
+    with pytest.raises(DeleteEdgeUseCase.ConnectingSameNodeError):
+        DeleteEdgeUseCase(
+            node_repo=mock_node_repo,
+        ).execute(
+            input_data=DeleteEdgeInputData(
+                node_ids=(1, 1),
+            ),
+        )
+
+
+def test_delete_edge_with_no_edge_between_nodes() -> None:
+    nodes: dict[int, Node] = {
+        1: Node(
+            id=1,
+            name="Node 1",
+            point=Point(
+                longitude=Decimal("1.0"),
+                latitude=Decimal("2.0"),
+            ),
+            edges=[],
+        ),
+        2: Node(
+            id=2,
+            name="Node 2",
+            point=Point(
+                longitude=Decimal("3.0"),
+                latitude=Decimal("4.0"),
+            ),
+            edges=[],
+        ),
+    }
+    mock_node_repo = mock.Mock(spec_set=NodeRepository)
+    side_effect: Callable[[int], Node] = lambda node_id: nodes[node_id]
+    mock_node_repo.get_node_by_id.side_effect = side_effect
+
+    with pytest.raises(DeleteEdgeUseCase.EdgeNotFoundError):
+        DeleteEdgeUseCase(
+            node_repo=mock_node_repo,
+        ).execute(
+            input_data=DeleteEdgeInputData(
+                node_ids=(1, 2),
+            ),
+        )
+
+    assert not mock_node_repo.update_node.called

--- a/tests/map_admin/domain/test_node.py
+++ b/tests/map_admin/domain/test_node.py
@@ -332,3 +332,104 @@ def test_update_edge_error_with_no_edge_between_nodes() -> None:
             is_step=False,
             quality=RoadQuality.HIGH,
         )
+
+
+def test_delete_edge() -> None:
+    nodes: dict[int, Node] = {
+        1: Node(
+            id=1,
+            name="Node 1",
+            point=Point(
+                longitude=Decimal("1.0"),
+                latitude=Decimal("2.0"),
+            ),
+            edges=[
+                Edge(
+                    node_ids=(1, 2),
+                    vertical_distance=Decimal("1.0"),
+                    horizontal_distance=Decimal("2.0"),
+                    is_stair=False,
+                    is_step=False,
+                    quality=RoadQuality.HIGH,
+                ),
+            ],
+        ),
+        2: Node(
+            id=2,
+            name="Node 2",
+            point=Point(
+                longitude=Decimal("3.0"),
+                latitude=Decimal("4.0"),
+            ),
+            edges=[
+                Edge(
+                    node_ids=(1, 2),
+                    vertical_distance=Decimal("1.0"),
+                    horizontal_distance=Decimal("2.0"),
+                    is_stair=False,
+                    is_step=False,
+                    quality=RoadQuality.HIGH,
+                ),
+            ],
+        ),
+    }
+    deleted_edge = Edge(
+        node_ids=(1, 2),
+        vertical_distance=Decimal("1.0"),
+        horizontal_distance=Decimal("2.0"),
+        is_stair=False,
+        is_step=False,
+        quality=RoadQuality.HIGH,
+    )
+
+    nodes[1].delete_edge(
+        other_node=nodes[2],
+    )
+
+    assert deleted_edge not in nodes[1].edges
+    assert deleted_edge not in nodes[2].edges
+
+
+def test_delete_edge_error_with_same_node() -> None:
+    node = Node(
+        id=1,
+        name="Node 1",
+        point=Point(
+            longitude=Decimal("1.0"),
+            latitude=Decimal("2.0"),
+        ),
+        edges=[],
+    )
+
+    with pytest.raises(ConnectingSameNodeError):
+        node.delete_edge(
+            other_node=node,
+        )
+
+
+def test_delete_edge_error_with_no_edge_between_nodes() -> None:
+    nodes: dict[int, Node] = {
+        1: Node(
+            id=1,
+            name="Node 1",
+            point=Point(
+                longitude=Decimal("1.0"),
+                latitude=Decimal("2.0"),
+            ),
+            edges=[],
+        ),
+        2: Node(
+            id=2,
+            name="Node 2",
+            point=Point(
+                longitude=Decimal("3.0"),
+                latitude=Decimal("4.0"),
+            ),
+            edges=[],
+        ),
+    }
+
+    with pytest.raises(NoEdgeExistsBetweenNodesError):
+        nodes[1].delete_edge(
+            other_node=nodes[2],
+        )


### PR DESCRIPTION
## Description
* 지도관리자 도메인의 간선 삭제 유스케이스를 제작합니다.
* 지도관리자 도메인의 간선 삭제 API를 제작합니다.


## Changes

### Domain
* Node 엔티티에 delete_edge() 메서드를 추가합니다. (+ 테스트 작성)

### Application
* DeleteEdgeInputData 정의
* DeleteEdgeInputBoundary, DeleteEdgeUseCase 정의 (+ 테스트 작성)

### Presentation
* delete_edge() path function 정의 (`DELETE edges/{node_id_1}/{node_id_2}`)

## Issues and References
#30
#51

